### PR TITLE
Add support for the Euro

### DIFF
--- a/class-camptix-payment-method-stripe.php
+++ b/class-camptix-payment-method-stripe.php
@@ -7,7 +7,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 	// See https://support.stripe.com/questions/which-currencies-does-stripe-support
 	// Only testing with AUD and USD though.
-	public $supported_currencies = array( 'AUD', 'USD' );
+	public $supported_currencies = array( 'AUD', 'USD', 'EUR' );
 
 	public $supported_features = array(
 		'refund-single' => true,


### PR DESCRIPTION
Eventually this should support all of the currencies that Stripe does, but that will require additional testing, especially with zero-decimal currencies. The Euro is very popular, and has been tested successfully, so let's start there.