### PR TITLE
Bugfixes (3)

### DIFF
--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -36,7 +36,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.unique(
+		var emails = jQuery.uniqueSort(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -38,7 +38,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.uniqueSort(
+		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -29,9 +29,11 @@ var CampTixStripe = new function() {
 			return;
 		}
 
-		self.stripe_checkout();
-
-		e.preventDefault();
+		// Check if the form is valid before allowing submission! -- NOTE: Requires updated camptix that adds proper required flags
+        if (self.form[0].checkValidity()) {
+            self.stripe_checkout();
+		    e.preventDefault();
+        }
 	}
 
 	self.stripe_checkout = function() {

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -36,7 +36,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.uniqueSort(
+		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/class-camptix-payment-method-stripe.php
+++ b/class-camptix-payment-method-stripe.php
@@ -59,13 +59,13 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		wp_register_script( 'stripe-checkout', 'https://checkout.stripe.com/checkout.js', array(), false, true );
-		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20170322', true );
+		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20180122', true );
 
 		wp_localize_script( 'camptix-stripe', 'CampTixStripeData', array(
 			'public_key'  => $this->options['api_public_key'],
 			'name'        => $this->camptix_options['event_name'],
 			'description' => trim( $description ),
-			'amount'      => (int) $camptix->order['total'] * 100,
+			'amount'      => round($camptix->order['total'] * 100),
 			'currency'    => $this->camptix_options['currency'],
 
 			'token'       => !empty( $_POST['tix_stripe_token'] ) ? wp_unslash( $_POST['tix_stripe_token'] ) : '',


### PR DESCRIPTION
Found a few bugs and have fixed them:

1. The form wasn't being validated before checkout, allowing for empty fields.
2. The software always made even-dollar prices, even if you were say using a 10% off discount code that should have gotten down to cents.  Fixed
3. The JS was using .uniqueSort(), but that's in jQuery 3.0 only, reverted it to .unique() which works in 2.x (and in 3.x)
