### PR TITLE
Adding additional Stripe Options

### DIFF
--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -36,7 +36,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.unique(
+		var emails = jQuery.uniqueSort(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -7,7 +7,13 @@ var CampTixStripe = new function() {
 
 	self.init = function() {
 		self.form = jQuery( '#tix form' );
-		self.form.on( 'submit', CampTixStripe.form_handler );
+		if (self.form.find( '#tix-pm-stripe' ).length) {
+		    // Hook up on click on the stripe button if buttons are active
+		    self.form.find( '#tix-pm-stripe' ).on( 'click', CampTixStripe.form_handler );
+		} else {
+		    // Hook up on submit of form otherwise
+    		self.form.on( 'submit', CampTixStripe.form_handler );
+		}
 
 		// On a failed attendee data request, we'll have the previous stripe token
 		if ( self.data.token ) {
@@ -17,10 +23,12 @@ var CampTixStripe = new function() {
 
 	self.form_handler = function(e) {
 		// Verify Stripe is the selected method.
-		var method = self.form.find('[name="tix_payment_method"]').val() || 'stripe';
+		if (self.form.find( '#tix-pm-stripe' ).length === 0) {
+    		var method = self.form.find('[name="tix_payment_method"]').val() || 'stripe';
 
-		if ( 'stripe' != method ) {
-			return;
+    		if ( 'stripe' != method ) {
+    			return;
+    		}
 		}
 
 		// If the form already has a Stripe token, bail.
@@ -37,14 +45,13 @@ var CampTixStripe = new function() {
 	}
 
 	self.stripe_checkout = function() {
-
 		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )
 		);
-
-		var StripeHandler = StripeCheckout.configure({
+		
+        var StripeHandler = StripeCheckout.configure({
 			key: self.data.public_key,
 			image: 'https://s.w.org/about/images/desktops/wp-blue-1024x768.png', //'https://stripe.com/img/documentation/checkout/marketplace.png',
 			locale: 'auto',
@@ -54,8 +61,7 @@ var CampTixStripe = new function() {
 			name: self.data.name,
 			zipCode: true,
 			email: ( emails.length == 1 ? emails[0] : '' ) || '',
-
-			token: self.stripe_token_callback,
+			token: self.stripe_token_callback
 		});
 
 		// Close the popup if they hit back.
@@ -67,8 +73,6 @@ var CampTixStripe = new function() {
 	};
 
 	self.stripe_token_callback = function( token ) {
-		console.log( token );
-
 		self.add_stripe_token_hidden_fields( token.id, token.receipt_email || token.email );
 		self.form.submit();
 	}
@@ -79,6 +83,14 @@ var CampTixStripe = new function() {
     			id: 'tix_stripe_token',
     			name: 'tix_stripe_token',
     			value: token_id,
+		}).appendTo( self.form );
+	
+        // Should only do this if the select doesn't exist:	
+        jQuery('<input>').attr({
+    			type: 'hidden',
+    			id: 'tix_payment_method',
+    			name: 'tix_payment_method',
+    			value: 'stripe',
 		}).appendTo( self.form );
 
 		if ( email ) {

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -38,7 +38,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.uniqueSort(
+		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -29,9 +29,11 @@ var CampTixStripe = new function() {
 			return;
 		}
 
-		self.stripe_checkout();
-
-		e.preventDefault();
+		// Check if the form is valid before allowing submission! -- NOTE: Requires updated camptix that adds proper required flags
+        if (self.form[0].checkValidity()) {
+            self.stripe_checkout();
+		    e.preventDefault();
+        }
 	}
 
 	self.stripe_checkout = function() {

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -45,22 +45,27 @@ var CampTixStripe = new function() {
 	}
 
 	self.stripe_checkout = function() {
-		var emails = jQuery.unique(
-			self.form.find('input[type="email"]')
-			.filter( function () { return this.value.length; })
-			.map( function() { return this.value; } )
-		);
-		
+        var emailopt = '';
+        if (!(self.data.ask_email)) {
+		    var emails = jQuery.unique(
+		    	self.form.find('input[type="email"]')
+		    	.filter( function () { return this.value.length; })
+		    	.map( function() { return this.value; } )
+		    );
+            emailopt = ( emails.length == 1 ? emails[0] : '' ) || '';
+        }
+
         var StripeHandler = StripeCheckout.configure({
 			key: self.data.public_key,
-			image: 'https://s.w.org/about/images/desktops/wp-blue-1024x768.png', //'https://stripe.com/img/documentation/checkout/marketplace.png',
+			image: self.data.logo_url ? self.data.logo_url : 'https://stripe.com/img/documentation/checkout/marketplace.png',
 			locale: 'auto',
 			amount: parseInt( this.data.amount ),
 			currency: self.data.currency,
 			description: self.data.description,
 			name: self.data.name,
 			zipCode: true,
-			email: ( emails.length == 1 ? emails[0] : '' ) || '',
+            billingAddress: self.data.ask_billing ? true : false,
+            email: emailopt,
 			token: self.stripe_token_callback
 		});
 

--- a/camptix-stripe.js
+++ b/camptix-stripe.js
@@ -36,7 +36,7 @@ var CampTixStripe = new function() {
 
 	self.stripe_checkout = function() {
 
-		var emails = jQuery.uniqueSort(
+		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 			.filter( function () { return this.value.length; })
 			.map( function() { return this.value; } )

--- a/class-camptix-payment-method-stripe.php
+++ b/class-camptix-payment-method-stripe.php
@@ -59,13 +59,13 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		wp_register_script( 'stripe-checkout', 'https://checkout.stripe.com/checkout.js', array(), false, true );
-		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20170322', true );
+		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20180122', true );
 
 		wp_localize_script( 'camptix-stripe', 'CampTixStripeData', array(
 			'public_key'  => $this->options['api_public_key'],
 			'name'        => $this->camptix_options['event_name'],
 			'description' => trim( $description ),
-			'amount'      => (int) $camptix->order['total'] * 100,
+			'amount'      => round($camptix->order['total'] * 100),
 			'currency'    => $this->camptix_options['currency'],
 
 			'token'       => !empty( $_POST['tix_stripe_token'] ) ? wp_unslash( $_POST['tix_stripe_token'] ) : '',

--- a/class-camptix-payment-method-stripe.php
+++ b/class-camptix-payment-method-stripe.php
@@ -59,7 +59,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		wp_register_script( 'stripe-checkout', 'https://checkout.stripe.com/checkout.js', array(), false, true );
-		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20180122', true );
+		wp_enqueue_script( 'camptix-stripe', plugins_url( 'camptix-stripe.js', __DIR__ . '/camptix-stripe-gateway.php' ), array( 'stripe-checkout', 'jquery' ), '20180124', true );
 
 		wp_localize_script( 'camptix-stripe', 'CampTixStripeData', array(
 			'public_key'  => $this->options['api_public_key'],


### PR DESCRIPTION
I created an addition to this plugin that gives a few more settings so that you can control your Stripe checkout:

1. Do you want to collect a separate billing email address from the ticket emails
2. Do you want to collect a full billing address instead of just a zip code
3. Able to configure what logo shows up on the checkout.